### PR TITLE
Contrib: Bug fix manually placed Flattr buttons

### DIFF
--- a/digg-digg/include/dd-manual.php
+++ b/digg-digg/include/dd-manual.php
@@ -114,8 +114,8 @@ $dd_manual_code = array(
 		"Compact" => "dd_pinterest_generate('Compact')"
 	),
 	"Flattr" => array(
-		"Normal" => "dd_flattr_generate('Normal')",
-		"Compact" => "dd_flattr_generate('Compact')"
+		"Normal" => "dd_flattr_generate('Normal','flattr_username')",
+		"Compact" => "dd_flattr_generate('Compact','flattr_username')"
 	),
 );		
 	
@@ -350,11 +350,14 @@ function dd_pinterest_generate($buttonDesign='Normal'){
 	echo $dd_pinterest->finalURL;
 }
 
-function dd_flattr_generate($buttonDesign='Normal'){
+function dd_flattr_generate($buttonDesign='Normal', $uid=''){
 	$post_data = dd_getPostData();
     
+	global $globalcfg;
+	$globalcfg[DD_GLOBAL_FLATTR_OPTION][DD_GLOBAL_FLATTR_OPTION_UID] = $uid;
+	
     $dd_flattr = new DD_Flattr();
-    $dd_flattr->constructURL($post_data['link'],$post_data['title'],$buttonDesign,$post_data['id'],false);
+    $dd_flattr->constructURL($post_data['link'],$post_data['title'],$buttonDesign,$post_data['id'],false,$globalcfg);
     
 	echo $dd_flattr->finalURL;
 }


### PR DESCRIPTION
Hi! Thanks for all the awesome social buttons :).

I was using your Digg Digg plugin and noticed that using the Flattr button with manual placement caused the button to credit a default Flattr user called "flattr." I updated the dd_flattr_generate function to work the same way your dd_twitter_generate function works. It passes a globalcfg variable into constructURL; constructURL was already designed to handle globalcfg, but dd_flattr_generate wasn't using the variable. 

I also updated the dd_manual_code array so it shows the correct manual placement code for flattr in the settings. Here's the new manual placement:
<?php dd_flattr_generate('Normal','flattr_username') ?> 

Modeled after:
<?php dd_twitter_generate('Normal','twitter_username') ?>

Hope this is helpful to everyone else trying to manually place the Flattr buttons. :) Thanks again!

Jimm
