### PR TITLE
HTTPS fix.

### DIFF
--- a/digg-digg/digg-digg.php
+++ b/digg-digg/digg-digg.php
@@ -10,17 +10,11 @@
               Simply Activate Digg Digg now to enhance your posts.
 */
 
-/*
-ini_set('display_errors',1);
-error_reporting(E_ALL);
-*/
-/* Define the file path */
-if (!defined("WP_CONTENT_URL")) define("WP_CONTENT_URL", get_option("siteurl") . "/wp-content");
-if (!defined("WP_PLUGIN_URL"))  define("WP_PLUGIN_URL", WP_CONTENT_URL . "/plugins");
-define('DD_PLUGIN_URL',WP_PLUGIN_URL . '/' . plugin_basename(dirname(__FILE__)).'/');
+define( 'DD_PLUGIN_URL', plugins_url( '/', __FILE__ ) );
 
 // fix for the W3 Total Cache bug (fixed in Digg Digg 5.1)
-if(function_exists('w3tc_objectcache_flush')) w3tc_objectcache_flush();
+if( function_exists( 'w3tc_objectcache_flush' ) )
+	w3tc_objectcache_flush();
 
 require_once 'include/dd-global-variable.php';
 require_once 'include/dd-printform.php';
@@ -30,13 +24,13 @@ require_once 'include/dd-upgrade.php';
 
 //http://codex.wordpress.org/Function_Reference/register_activation_hook
 //function to be run when the plugin is activated
-register_activation_hook( __FILE__, 'dd_run_when_plugin_activated');
+register_activation_hook( __FILE__, 'dd_run_when_plugin_activated' );
 
-add_action('init', 'dd_enable_required_js_in_wordpress');
-add_action('wp_head', 'dd_output_css_to_html');
-add_action('wp_head', 'dd_get_thumbnails_for_fb');
-add_filter('the_excerpt', 'dd_hook_wp_content');
-add_filter('the_content', 'dd_hook_wp_content');
+add_action('init', 'dd_enable_required_js_in_wordpress' );
+add_action( 'wp_head', 'dd_wp_enqueue_styles' );
+add_action( 'wp_head', 'dd_get_thumbnails_for_fb' );
+add_filter( 'the_excerpt', 'dd_hook_wp_content' );
+add_filter( 'the_content', 'dd_hook_wp_content' );
 
 function dd_hook_wp_content($content = ''){
 	if(dd_isThisPageExcluded($content)==true){
@@ -49,11 +43,11 @@ function dd_hook_wp_content($content = ''){
 	$postlink = get_permalink($id); //get post link
 	$commentcount = $post->comment_count; //get post comment count
 	$title = trim($post->post_title); // get post title
-	$link = explode(DD_DASH,$postlink); //split the link with '#', for comment link 
+	$link = explode(DD_DASH,$postlink); //split the link with '#', for comment link
 	$url = $link[0];
 
 	$dd_global_config = get_option(DD_GLOBAL_CONFIG);
-	
+
 	$ddNormalDisplay = get_option(DD_NORMAL_DISPLAY_CONFIG);
 	$content = process_normal_button_display($ddNormalDisplay, $content, $url, $title, $id, $commentcount, $dd_global_config);
 
@@ -64,64 +58,64 @@ function dd_hook_wp_content($content = ''){
 }
 
 function process_normal_button_display($ddNormalDisplay, $content, $url, $title, $id, $commentcount, $dd_global_config){
-	
+
 	if(isNormalButtonAllowDisplay($ddNormalDisplay)){
-			
+
 		$dd_normal_button_for_display = constructNormalButtons($url, $title, $id, $commentcount, $dd_global_config);
 		$dd_line_up = getNormalButtonLineUpOption($ddNormalDisplay);
 		$modified_content = integrateNormalButtonsIntoWpContent($dd_normal_button_for_display,$content,$dd_line_up);
 		return $modified_content;
-		
+
 	}else{
-		
+
 		return $content;
-		
+
 	}
-	
+
 }
 
 function isNormalButtonAllowDisplay($ddNormalDisplay){
-	
+
 	if($ddNormalDisplay[DD_STATUS_OPTION][DD_STATUS_OPTION_DISPLAY]==DD_DISPLAY_ON){
 		if(dd_IsDisplayAllow($ddNormalDisplay)){
 			return true;
 		}
 	}
-	
+
 }
 
 function getNormalButtonLineUpOption($ddNormalDisplay){
 	//horizontal or vertical
-	return $ddNormalDisplay[DD_LINE_UP_OPTION][DD_LINE_UP_OPTION_SELECT]; 
-	
+	return $ddNormalDisplay[DD_LINE_UP_OPTION][DD_LINE_UP_OPTION_SELECT];
+
 }
 
 function constructNormalButtons($url, $title, $id, $commentcount, $dd_global_config){
-	
-	$dd_display_buttons = get_option(DD_NORMAL_BUTTON);	
+
+	$dd_display_buttons = get_option(DD_NORMAL_BUTTON);
 	$dd_sorting_data = array();
 
 	foreach(array_keys($dd_display_buttons[DD_NORMAL_BUTTON_FINAL]) as $key){
 
 		$obj = $dd_display_buttons[DD_NORMAL_BUTTON_FINAL][$key];
-		
+
 		if($obj->name == "Comments"){
 
 			$obj->constructURL($url,$title,$obj->getOptionButtonDesign(),$id, $obj->getOptionLazyLoad(), $dd_global_config,$commentcount);
-			
+
 		}else{
-			
+
 			$obj->constructURL($url,$title,$obj->getOptionButtonDesign(),$id, $obj->getOptionLazyLoad(), $dd_global_config);
-		
+
 		}
-			
+
 		$dd_sorting_data[$obj->getOptionButtonWeight().'-'.$obj->name] = $obj;
 	}
-	
+
 	krsort($dd_sorting_data,SORT_NUMERIC);
-	
+
 	return $dd_sorting_data;
-	
+
 }
 
 function integrateNormalButtonsIntoWpContent($dd_normal_button_for_display, $content, $dd_line_up){
@@ -149,16 +143,16 @@ function integrateNormalButtonsIntoWpContent($dd_normal_button_for_display, $con
 
 		if($obj->getOptionAppendType() == DD_SELECT_LEFT_FLOAT){
 			$dd_left_float .= generateNormalButtonDiv($finalURL,$dd_line_up,$name);
-			
+
 		}else if($obj->getOptionAppendType() == DD_SELECT_RIGHT_FLOAT){
 			$dd_right_float .= generateNormalButtonDiv($finalURL,$dd_line_up,$name);
-			
+
 		}else if($obj->getOptionAppendType() == DD_SELECT_BEFORE_CONTENT){
 			$dd_before_content .= generateNormalButtonDiv($finalURL,$dd_line_up,$name);
-			
+
 		}else if($obj->getOptionAppendType() == DD_SELECT_AFTER_CONTENT){
 			$dd_after_content .= generateNormalButtonDiv($finalURL,$dd_line_up,$name);
-			
+
 		}
 
 	}
@@ -188,23 +182,23 @@ function integrateNormalButtonsIntoWpContent($dd_normal_button_for_display, $con
 		//$scheduler = "<script type=\"text/javascript\">function dd_init(){ jQuery(document).ready(function($) { " . $dd_scheduler_script . " }); }</script>";
 		$scheduler = "<script type=\"text/javascript\"> jQuery(document).ready(function($) { " . $dd_scheduler_script . " }); </script>";
 	}
-	
+
 	$normalBarJS = '<script type="text/javascript" src="' . DD_PLUGIN_URL . '/js/diggdigg-linkedin.js?ver=' . DD_VERSION . '"></script>';
-	
+
 	$content = $dd_left_float . $dd_right_float . $dd_before_content . $content . $dd_after_content . $scheduler . $dd_jQuery_script . $normalBarJS . DD_AUTHOR_SITE;
 
 	return $content;
-	
+
 }
 
 function generateNormalButtonDiv($finalURL, $dd_line_up,$name){
 
 	$result ='';
-	
+
 	if($dd_line_up==DD_LINE_UP_OPTION_SELECT_HORIZONTAL){
-		
+
 		$result = "<div class='dd_button'>" .$finalURL. "</div>" ;
-		
+
 	}else if($dd_line_up==DD_LINE_UP_OPTION_SELECT_VERTICAL){
 
 		//TODO:for facebook only?
@@ -216,29 +210,29 @@ function generateNormalButtonDiv($finalURL, $dd_line_up,$name){
 		}
 
 	}else{
-		
+
 		$result = "<div class='dd_button'>" . $finalURL . "</div>" ;
-		
+
 	}
-	
+
 	return $result;
 
 }
 
 function process_floating_button_display($ddFloatDisplay, $content, $url, $title, $id, $commentcount, $dd_global_config){
-	
+
 	if(isFloatingButtonAllowDisplay($ddFloatDisplay)){
-			
+
 		$dd_floating_button_for_display = constructFloatingButtons($url, $title, $id, $commentcount, $dd_global_config);
 		$modified_content = integrateFloatingButtonsIntoWpContent($dd_floating_button_for_display, $content, $ddFloatDisplay);
 		return $modified_content;
-		
+
 	}else{
-		
+
 		return $content;
-		
+
 	}
-	
+
 }
 
 function isFloatingButtonAllowDisplay($ddFloatDisplay){
@@ -251,12 +245,12 @@ function isFloatingButtonAllowDisplay($ddFloatDisplay){
 			return true;
 		}
 	}
-	
+
 }
 
 function constructFloatingButtons($url, $title, $id, $commentcount, $dd_global_config){
-	
-	$dd_display_buttons = get_option(DD_FLOAT_BUTTON);	
+
+	$dd_display_buttons = get_option(DD_FLOAT_BUTTON);
 	$dd_sorting_data = array();
 
 	global $wp_query;
@@ -279,7 +273,7 @@ function constructFloatingButtons($url, $title, $id, $commentcount, $dd_global_c
 				//get current page URL, not post URL
 				//get default button design
 				$obj->constructURL(getCurPageURL(),$dd_title,$obj->float_button_design,$id, $obj->getOptionLazyLoad(), $dd_global_config,$commentcount);
-				 
+
 				$dd_sorting_data[$obj->getOptionButtonWeight().'-'.$obj->name] = $obj;
 			}
 		}
@@ -298,13 +292,13 @@ function constructFloatingButtons($url, $title, $id, $commentcount, $dd_global_c
 	krsort($dd_sorting_data,SORT_NUMERIC);
 
 	return $dd_sorting_data;
-	
+
 }
 
 function integrateFloatingButtonsIntoWpContent($dd_floating_button_for_display,$content,$ddFloatDisplay){
-	
+
 	global $dd_floating_bar;
-	
+
 	$floatButtonsContainer=DD_EMPTY_VALUE;
 	$dd_lazyLoad_jQuery_script =DD_EMPTY_VALUE;
 	$dd_lazyLoad_scheduler_script =DD_EMPTY_VALUE;
@@ -321,7 +315,7 @@ function integrateFloatingButtonsIntoWpContent($dd_floating_button_for_display,$
 			$dd_lazyLoad_jQuery_script.=$obj->finalURL_lazy_script;
 			$dd_lazyLoad_scheduler_script.=$obj->final_scheduler_lazy_script;
 		}
-		
+
 		$floatButtonsContainer .= "<div class='dd_button_v'>" . $finalURL . "</div><div style='clear:left'></div>";
 
 	}
@@ -337,22 +331,22 @@ function integrateFloatingButtonsIntoWpContent($dd_floating_button_for_display,$
 		if($dd_lazyLoad_scheduler_script!=DD_EMPTY_VALUE){
 			$dd_lazyLoad_scheduler_script = "<script type=\"text/javascript\"> jQuery(document).ready(function($) { " . $dd_lazyLoad_scheduler_script . " }); </script>";
 		}
-		
+
 		// $floatingCSS = '<style type="text/css" media="screen">' . $ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_INITIAL_POSITION] . '</style>';
 		$floatingJSOptions = '<script type="text/javascript">var dd_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT])?($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT]):DD_FLOAT_OPTION_LEFT_VALUE).'; var dd_top_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_TOP])?($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_TOP]):DD_FLOAT_OPTION_TOP_VALUE).';</script>';
 		$floatingJS = '<script type="text/javascript" src="' . DD_PLUGIN_URL . '/js/diggdigg-floating-bar.js?ver=' . DD_VERSION . '"></script>';
 
 		$dd_floating_bar = "<div class='dd_outer'><div class='dd_inner'>" . $floatButtonsContainer . "</div></div>" . $floatingJSOptions . $floatingJS . $dd_lazyLoad_scheduler_script . $dd_lazyLoad_jQuery_script;
 		$dd_start_anchor = '<a id="dd_start"></a>';
-		
+
 		if(!$ddFloatDisplay[DD_COMMENT_ANCHOR_OPTION][DD_COMMENT_ANCHOR_OPTION_STATUS]){
 			$dd_end_anchor = '<a id="dd_end"></a>';
 		} else {
 			$dd_end_anchor = '';
 		}
-		
+
 		$content =  $dd_start_anchor . $content . $dd_end_anchor . $dd_floating_bar;
-	
+
 	}
 
 	return $content;
@@ -362,7 +356,7 @@ function integrateFloatingButtonsIntoWpContent($dd_floating_button_for_display,$
 function integrateFloatingButtonsIntoWpContent_footerload($dd_floating_button_for_display,$content,$ddFloatDisplay){
 
 	global $dd_floating_bar;
-	
+
 	$floatButtonsContainer=DD_EMPTY_VALUE;
 	$dd_lazyLoad_jQuery_script =DD_EMPTY_VALUE;
 	$dd_lazyLoad_scheduler_script =DD_EMPTY_VALUE;
@@ -395,81 +389,81 @@ function integrateFloatingButtonsIntoWpContent_footerload($dd_floating_button_fo
 		if($dd_lazyLoad_scheduler_script!=DD_EMPTY_VALUE){
 			$dd_lazyLoad_scheduler_script = "<script type=\"text/javascript\">function dd_float_scheduler(){ jQuery(document).ready(function($) { " . $dd_lazyLoad_scheduler_script . " }); }</script>";
 		}
-		
+
 		// $floatingCSS = '<style type="text/css" media="screen">' . $ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_INITIAL_POSITION] . '</style>';
 		$floatingJSOptions = '<script type="text/javascript">var dd_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT])?($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT]):DD_FLOAT_OPTION_LEFT_VALUE).';</script>';
 		$floatingJS = '<script type="text/javascript" src="' . DD_PLUGIN_URL . '/js/diggdigg-floating-bar.js?ver=' . DD_VERSION . '"></script>';
-		
+
 		$dd_floating_bar = "<div class='dd_outer'><div class='dd_inner'>" . $floatButtonsContainer . "</div></div>" . $floatingCSS . $floatingJSOptions . $floatingJS . $dd_lazyLoad_scheduler_script . $dd_lazyLoad_jQuery_script;
-		
+
 		$dd_start_anchor = '<a id="dd_start"></a>';
-		
+
 		if(!$ddFloatDisplay[DD_COMMENT_ANCHOR_OPTION][DD_COMMENT_ANCHOR_OPTION_STATUS]){
 			$dd_end_anchor = '<a id="dd_end"></a>';
 		} else {
 			$dd_end_anchor = '';
 		}
-		
+
 		$content =  $dd_start_anchor . $content . $dd_end_anchor . $dd_floating_bar;
-	
+
 	}
 
 	return $content;
 }
 
 function dd_construct_final_floating_buttons($floatButtonsContainer, $ddFloatDisplay){
-	
+
 	if($ddFloatDisplay[DD_EXTRA_OPTION_EMAIL][DD_EXTRA_OPTION_EMAIL_STATUS]==DD_DISPLAY_ON){
 
 		$emailContainer = dd_get_email_service($ddFloatDisplay[DD_EXTRA_OPTION_EMAIL][DD_EXTRA_OPTION_EMAIL_SHARETHIS_PUB_ID]);
 		$floatButtonsContainer .= $emailContainer;
-		
+
 	}
-		
+
 	if($ddFloatDisplay[DD_EXTRA_OPTION_PRINT][DD_EXTRA_OPTION_PRINT_STATUS]==DD_DISPLAY_ON){
 
 		$printContainer = dd_get_print_service();
 		$floatButtonsContainer .= $printContainer;
-		
+
 	}
-	
+
 	if (dd_is_credit_link_enabled($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_CREDIT])){
 		$floatButtonsContainer .= FLOAT_BUTTON_CREDIT_LINK;
 	}
-	
+
 	$floatButtonsContainer = "<div id='dd_ajax_float'>" . $floatButtonsContainer . "</div>";
-	
+
 	return $floatButtonsContainer;
-		
+
 }
 
 //http://help.sharethis.com/customization/custom-buttons
 //http://help.sharethis.com/customization/chicklets
 function dd_get_email_service($ddShareThisPubId){
-	
+
 	$emailButton = "<div class='dd_button_extra_v'><script type=\"text/javascript\">jQuery(document).load(function(){ stLight.options({";
 	$emailButton .= "publisher:'". $ddShareThisPubId ."'";
 	$emailButton .= "}); });</script><div class=\"st_email_custom\"><span id='dd_email_text'>email</span></div></div><div style='clear:left'></div>";
 
 	return $emailButton;
-	
+
 }
 
 function dd_get_print_service(){
-	
+
 	$emailButton = "<div class='dd_button_extra_v'><div id='dd_print_button'><span id='dd_print_text'><a href='javascript:window:print()'>print</a></span></div></div><div style='clear:left'></div>";
 	return $emailButton;
-	
+
 }
 
 function dd_is_credit_link_enabled($creditLinkStatus){
-	
+
 	if($creditLinkStatus==DD_DISPLAY_ON){
 		return true;
 	}else{
 		return false;
 	}
-	
+
 }
 
 /********************************************************
@@ -479,9 +473,9 @@ add_action('admin_init', 'dd_admin_init_setting');
 add_action('admin_menu', 'dd_admin_generate_menu_link');
 
 function dd_admin_generate_menu_link() {
-	
+
 	$page = add_menu_page('Digg Digg', 'Digg Digg', 'manage_options', 'dd_button_setup');
-	
+
 	$dd_button_global_setup = add_submenu_page('dd_button_setup', 'Digg Digg - Global Configuration', 'Global Config', 'manage_options', 'dd_button_setup', 'dd_button_global_setup');
 	$dd_page_for_normal_display = add_submenu_page('dd_button_setup', 'Digg Digg - Normal Button Configuration ', 'Normal Display', 'manage_options', 'dd_page_for_normal_display', 'dd_page_for_normal_display');
 	$dd_page_for_floating_display = add_submenu_page('dd_button_setup', 'Digg Digg - Floating Button Configuration', 'Floating Display', 'manage_options', 'dd_page_for_floating_display', 'dd_page_for_floating_display');
@@ -492,7 +486,7 @@ function dd_admin_generate_menu_link() {
 	add_action('admin_print_styles-' .$dd_page_for_normal_display, 'dd_admin_output_admin_css');
 	add_action('admin_print_styles-' .$dd_page_for_floating_display, 'dd_admin_output_admin_css');
 	add_action('admin_print_styles-' .$dd_button_manual_setup, 'dd_admin_output_admin_css');
-	
+
 }
 
 function dd_admin_init_setting() {
@@ -506,35 +500,35 @@ $dd_current_version = 5;
 function dd_check_if_client_need_upgrade_setting() {
 
 	global $dd_current_version;
-	
+
 	$dd_client_version = get_option('dd_client_version');
-	//print_r('$dd_current_version : [' . $dd_current_version . ']<br/>');	
-	//print_r('$dd_client_version : [' . $dd_client_version . ']<br/>');	
-	
+	//print_r('$dd_current_version : [' . $dd_current_version . ']<br/>');
+	//print_r('$dd_client_version : [' . $dd_client_version . ']<br/>');
+
 	if(empty($dd_client_version)){
-	
-		//print_r('$dd_client_upgrade_version is empty - first time<br/>');	
+
+		//print_r('$dd_client_upgrade_version is empty - first time<br/>');
 		//do first time setting upgrade
 		dd_upgrade_setting_version_1();
 		update_option('dd_client_version', $dd_current_version);
-		
+
 	}else{
-		
+
 		//print_r('$dd_client_upgrade_version is not empty - not first time<br/>');
-			
+
 		if($dd_current_version > $dd_client_version){
-			
+
 			//print_r('<h1>setting is upgrading.....</h1>');
 			dd_upgrade_setting_version_5();
 			update_option('dd_client_version', $dd_current_version);
-			
+
 		}else{
 			//print_r('setting is up to date<br/>');
 			//update_option('dd_client_version', 2);
 		}
 		//delete_option('dd_client_version');
 	}
-		
+
 }
 
 function dd_admin_output_admin_css(){

--- a/digg-digg/include/dd-helper.php
+++ b/digg-digg/include/dd-helper.php
@@ -1,14 +1,14 @@
 <?php
 require_once 'dd-global-variable.php';
 
-//3.1 : This hook is now fired only when the user activates the plugin and not when an automatic plugin update occurs 
+//3.1 : This hook is now fired only when the user activates the plugin and not when an automatic plugin update occurs
 ////http://codex.wordpress.org/Function_Reference/register_activation_hook
 function dd_run_when_plugin_activated(){
 
 	dd_clear_form_global_config();
 	dd_clear_form_normal_display();
 	dd_clear_form_float_display();
-	
+
 }
 
 function dd_clear_all_forms_settings(){
@@ -16,104 +16,103 @@ function dd_clear_all_forms_settings(){
 	dd_clear_form_global_config(DD_FUNC_TYPE_RESET);
 	dd_clear_form_normal_display(DD_FUNC_TYPE_RESET);
 	dd_clear_form_float_display(DD_FUNC_TYPE_RESET);
-	
+
 }
 
 function dd_clear_form_global_config($type=""){
-	
+
 	global $ddGlobalConfig;
-	
+
 	$old_ddGlobalConfig = get_option(DD_GLOBAL_CONFIG);
-	
+
 	if(empty($old_ddGlobalConfig) || $type==DD_FUNC_TYPE_RESET){
-		
+
 		//update $ddGlobalConfig to default setting
 		update_option(DD_GLOBAL_CONFIG, $ddGlobalConfig);
-		
+
 	}
-	
+
 }
 
 function dd_clear_form_normal_display($type=""){
-	
+
 	global $ddNormalDisplay,$ddNormalButtons;
-	
+
 	$dd_Old_NormalDisplay = get_option(DD_NORMAL_DISPLAY_CONFIG);
-	
+
 	if(empty($dd_Old_NormalDisplay) || $type==DD_FUNC_TYPE_RESET){
 
 		//update $ddNormalDisplay to default setting
 		update_option(DD_NORMAL_DISPLAY_CONFIG, $ddNormalDisplay);
-		
+
 	}
-	
+
 	foreach($ddNormalButtons[DD_NORMAL_BUTTON_DISPLAY] as $key => $value){
 
 		if(($value->getOptionAppendType()!=DD_SELECT_NONE)){
 			$ddNormalButtons[DD_NORMAL_BUTTON_FINAL][$key] = $value;
 		}
     }
-	
+
 	$dd_Old_NormalButton = get_option(DD_NORMAL_BUTTON);
-	
+
 	if(empty($dd_Old_NormalButton) || $type==DD_FUNC_TYPE_RESET){
-		
+
 		//update $ddNormalButtons to default setting
 		update_option(DD_NORMAL_BUTTON, $ddNormalButtons);
-		
+
 	}
-	
+
 }
 
 function dd_clear_form_float_display($type=""){
-	
+
 	global $ddFloatDisplay,$ddFloatButtons;
-	
+
 	$dd_Old_FloatDisplay = get_option(DD_FLOAT_DISPLAY_CONFIG);
-	
+
 	if(empty($dd_Old_FloatDisplay) || $type==DD_FUNC_TYPE_RESET){
-		
+
 		//update $ddFloatDisplay to default setting
 		update_option(DD_FLOAT_DISPLAY_CONFIG, $ddFloatDisplay);
-		
+
 	}
-	
+
 	foreach($ddFloatButtons[DD_FLOAT_BUTTON_DISPLAY] as $key => $value){
 
 		if(($value->getOptionAjaxLeftFloat()!=DD_DISPLAY_OFF)){
 			$ddFloatButtons[DD_FLOAT_BUTTON_FINAL][$key] = $value;
 		}
-		    	
+
     }
-	
+
 	$dd_Old_FloatButton = get_option(DD_FLOAT_BUTTON);
-	
+
 	if(empty($dd_Old_FloatButton) || $type==DD_FUNC_TYPE_RESET){
-		
+
 		//update $ddFloatButtons to default setting
 		update_option(DD_FLOAT_BUTTON, $ddFloatButtons);
-		
+
 	}
-	
+
 }
 
-function dd_output_css_to_html()
-{
-	echo '<link rel="stylesheet" href="' . DD_PLUGIN_URL . 'css/diggdigg-style.css?ver=' . DD_VERSION . '" type="text/css" media="screen" />';
+function dd_wp_enqueue_styles() {
+	wp_enqueue_style( 'digg-digg', plugins_url( 'css/diggdigg-style.css', dirname( __FILE__ ) ), array(), DD_VERSION, 'screen' );
 }
 
 function dd_get_thumbnails_for_fb()
 {
 	//check ig crawl is allowed
 	$globalcfg = get_option(DD_GLOBAL_CONFIG);
-	
+
 	$fb_thumb = $globalcfg[DD_GLOBAL_FACEBOOK_OPTION][DD_GLOBAL_FACEBOOK_OPTION_THUMB];
-	
+
 	if($fb_thumb==DD_DISPLAY_ON){
-		
+
 		global $posts;
 		$default = $globalcfg[DD_GLOBAL_FACEBOOK_OPTION][DD_GLOBAL_FACEBOOK_OPTION_DEFAULT_THUMB];
-	
+
 		$content = $posts[0]->post_content;
 		$output = preg_match_all( '/<img.+src=[\'"]([^\'"]+)[\'"].*>/i', $content, $matches);
 		if ($output > 0){
@@ -121,16 +120,16 @@ function dd_get_thumbnails_for_fb()
 		}else{
 			$thumb = $default;
 		}
-			
+
 		echo "<link rel=\"image_src\" href=\"$thumb\" />";
-	
+
 	}
-	
+
 }
 
 //http://codex.wordpress.org/Function_Reference/wp_enqueue_script
 function dd_enable_required_js_in_wordpress() {
-	
+
 	$ddFloatDisplay = get_option(DD_FLOAT_DISPLAY_CONFIG);
 	$email_option = ($ddFloatDisplay[DD_EXTRA_OPTION_EMAIL][DD_EXTRA_OPTION_EMAIL_STATUS]==DD_DISPLAY_ON);
 	if(!empty($email_option))
@@ -139,7 +138,7 @@ function dd_enable_required_js_in_wordpress() {
 		wp_register_script('dd_sharethis_js', 'http://w.sharethis.com/button/buttons.js');
 		wp_enqueue_script('dd_sharethis_js','http://w.sharethis.com/button/buttons.js',array('sharethis'),'1.0.0',true);
 	}
-	
+
 	if (!is_admin()) {
 
 		//jQuery need to put on head
@@ -149,15 +148,15 @@ function dd_enable_required_js_in_wordpress() {
 
 //filter for ajax floating javascript
 function dd_filter_weird_characters($str){
-	
+
 	$str = str_replace("\\\"", "\"", $str);
 	$str = str_replace("\'", "'", $str);
-	
+
 	return $str;
 }
 
 function dd_IsDisplayAllow($ddDisplay){
-	
+
 	if(dd_IsDisplayOptionAllow($ddDisplay[DD_DISPLAY_OPTION],$ddDisplay[DD_CATEORY_OPTION])){
 		return true;
 	}else{
@@ -169,10 +168,10 @@ function dd_IsDisplayAllow($ddDisplay){
  * Check if the current page allow to display button
  * @param $ddDisplayOptions -> $ddNormalDisplay[DD_DISPLAY_OPTION])
  * @param $ddCategoryOptions -> $ddNormalDisplay[DD_CATEORY_OPTION]
- * 
+ *
  */
 function dd_IsDisplayOptionAllow($ddDisplayOptions, $ddCategoryOptions){
-	
+
 	//get display option
     $dd_display_home = $ddDisplayOptions[DD_DISPLAY_OPTION_HOME];
 	$dd_display_page = $ddDisplayOptions[DD_DISPLAY_OPTION_PAGE];
@@ -180,7 +179,7 @@ function dd_IsDisplayOptionAllow($ddDisplayOptions, $ddCategoryOptions){
 	$dd_display_category = $ddDisplayOptions[DD_DISPLAY_OPTION_CAT];
 	$dd_display_tag = $ddDisplayOptions[DD_DISPLAY_OPTION_TAG];
 	$dd_display_archive = $ddDisplayOptions[DD_DISPLAY_OPTION_ARCHIVE];
-	
+
 	//TODO: can it display in feed?
 	$dd_display_feed = DD_DISPLAY_OFF;
 
@@ -189,11 +188,11 @@ function dd_IsDisplayOptionAllow($ddDisplayOptions, $ddCategoryOptions){
 	}else if(is_feed() && ($dd_display_feed==DD_DISPLAY_ON)){
 		return true;
 	}else if(is_single() && ($dd_display_post==DD_DISPLAY_ON)){
-		
+
 		//check category allow
 		return dd_IsCategoryAllow($ddCategoryOptions);
-		
-		
+
+
 	}else if(is_category() && ($dd_display_category==DD_DISPLAY_ON)){
 		return true;
 	}else if(is_page() && ($dd_display_page==DD_DISPLAY_ON)){
@@ -214,7 +213,7 @@ function dd_IsDisplayOptionAllow($ddDisplayOptions, $ddCategoryOptions){
  * @param $key - array key
  */
 function dd_GetText($id, $key){
-	
+
 	if($id==DD_DISPLAY_OPTION){
 		switch($key){
 			case DD_DISPLAY_OPTION_HOME :
@@ -259,13 +258,13 @@ function dd_GetText($id, $key){
  * @return "true" if page excluded
  */
 function dd_isThisPageExcluded($content){
-	
+
 	if (preg_match("/" . DD_DISABLED . "/i", $content)) {
 	    return true;
 	} else {
 	    return false;
 	}
-	
+
 }
 
 /**
@@ -273,36 +272,36 @@ function dd_isThisPageExcluded($content){
  * @param $category_options -> $ddNormalDisplay[DD_CATEORY_OPTION])
  */
 function dd_IsCategoryAllow($category_options){
-	
+
 	$catOptions = $category_options[DD_CATEORY_OPTION_RADIO];
 	$catOptionsInclude = $category_options[DD_CATEORY_OPTION_TEXT_INCLUDE];
 	$catOptionsExclude = $category_options[DD_CATEORY_OPTION_TEXT_EXCLUDE];
-	
+
 	if($catOptions == DD_CATEORY_OPTION_RADIO_INCLUDE){
-		
+
 		return dd_IsCategoryInclude($catOptionsInclude);
-		
+
 	}else if($catOptions == DD_CATEORY_OPTION_RADIO_EXCLUDE){
 
 		return !dd_IsCategoryExclude($catOptionsExclude);
-		
+
 	}else{
-		
+
 		return dd_IsCategoryInclude($catOptionsInclude);
 	}
-	
+
 }
 
 /**
- * 
+ *
  * @param $category_allow - categories allow to display
  * @return true = allow, false = disallow
  */
 function dd_IsCategoryInclude($category_allow){
-	
+
 	$category_allow = trim(strtolower($category_allow));
-	
-	//echo 'Category allow : ' . $category_allow; 
+
+	//echo 'Category allow : ' . $category_allow;
 	if($category_allow == '' || ($category_allow==strtolower(DD_ALL_VALUE))){
 		return true;
 	}
@@ -310,10 +309,10 @@ function dd_IsCategoryInclude($category_allow){
 	$cats_allow = explode(",", strtolower($category_allow));
 
 	foreach((get_the_category()) as $post_category) {
-		
-		//echo '<br/> category name : ' . $post_category->cat_name; 
+
+		//echo '<br/> category name : ' . $post_category->cat_name;
 		foreach($cats_allow as $cat_allow){
-			
+
 			$post_category_name = strtolower($post_category->cat_name);
 			//echo '<br/>Category allow loop : ' . $cat_allow . '<br/> current category name : ' . $post_category_name;
 
@@ -329,15 +328,15 @@ function dd_IsCategoryInclude($category_allow){
 }
 
 /**
- * 
+ *
  * @param $category_disallow - categories disallow to display
  * @return true = disallow, false = allow
  */
 function dd_IsCategoryExclude($category_disallow){
-	
+
 	$category_disallow = trim(strtolower($category_disallow));
-	
-	//echo 'Category disallow : ' . $category_disallow; 
+
+	//echo 'Category disallow : ' . $category_disallow;
 	if($category_disallow == '' || ($category_disallow==strtolower(DD_NONE_VALUE))){
 		return false;
 	}
@@ -345,10 +344,10 @@ function dd_IsCategoryExclude($category_disallow){
 	$cats_disallow = explode(",", strtolower($category_disallow));
 
 	foreach((get_the_category()) as $post_category) {
-		
-		//echo '<br/> category name : ' . $post_category->cat_name; 
+
+		//echo '<br/> category name : ' . $post_category->cat_name;
 		foreach($cats_disallow as $cat_disallow){
-			
+
 			$post_category_name = strtolower($post_category->cat_name);
 			//echo '<br/>Category allow loop : ' . $cat_disallow . '<br/> current category name : ' . $post_category_name;
 
@@ -362,7 +361,7 @@ function dd_IsCategoryExclude($category_disallow){
 	}
 	return false;
 }
-	
+
 function get_server() {
 	$protocol = 'http';
 	if (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == '443') {
@@ -378,18 +377,18 @@ function get_server() {
 
 function getCurPageURL() {
 	 $pageURL = 'http';
-	 
+
 	 if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {
 	 	$pageURL .= "s";
 	 }
 	 $pageURL .= "://";
-	 
+
 	 if ($_SERVER["SERVER_PORT"] != "80") {
 	  	$pageURL .= $_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"].$_SERVER["REQUEST_URI"];
 	 } else {
 	  	$pageURL .= $_SERVER["SERVER_NAME"].$_SERVER["REQUEST_URI"];
 	 }
-	 
+
 	 return $pageURL;
 }
 
@@ -397,29 +396,29 @@ function getCurPageURL() {
 $ddNormalDisplayTemp = get_option(DD_NORMAL_DISPLAY_CONFIG);
 //if diggdigg excerp is allow
 if($ddNormalDisplayTemp[DD_EXCERP_OPTION][DD_EXCERP_OPTION_DISPLAY]==DD_DISPLAY_ON){
-    	
+
 	remove_filter('get_the_excerpt', 'wp_trim_excerpt');
 	add_filter('get_the_excerpt', 'dd_exclude_js_trim_excerpt');
-	
+
 }
 
 //clone from wordpress 3.0.1 wp_trim_excerpt, add extra js filter
 function dd_exclude_js_trim_excerpt($text) {
-	
+
 	// Only generate excerpt if it does not exist
 	if($text==''){
-		
+
 		$text = get_the_content('');
 		$text = strip_shortcodes( $text );
-	
+
 		$text = apply_filters('the_content', $text);
-	
+
 		//exclude js script , in order to display button in the_excerpt() mode
 		$text = preg_replace('@<script[^>]*?>.*?</script>@si', '', $text);
-		
+
 		//exclude css , in order to display ajax float button in the_excerpt() mode
 		$text = preg_replace('@<style[^>]*?>.*?</style>@si', '', $text);
-		
+
 		$text = str_replace(']]>', ']]&gt;', $text);
 		$text = strip_tags($text);
 		$excerpt_length = apply_filters('excerpt_length', 55);
@@ -432,7 +431,7 @@ function dd_exclude_js_trim_excerpt($text) {
 		} else {
 			$text = implode(' ', $words);
 		}
-	
+
 	}
 	return $text;
 }
@@ -440,19 +439,19 @@ function dd_exclude_js_trim_excerpt($text) {
 //not implement yet
 //make sure wordpress > 2.3 and PHP >= 5
 function dd_check_version(){
-	
+
 	global $wp_version;
-	
+
 	echo '<h1>Current PHP version: ' . phpversion() . '</h1>';
-	
+
 	echo '<h1>Current Wordpress version: ' . $wp_version . '</h1>';
-	
+
 	$exit_msg="<div id='errmessage' class='error fade'><p>Digg Digg requires WordPress 2.3 or newer. <a href='http://codex.wordpress.org/Upgrading_WordPress'>Please update!</a></p></div>";
-	
+
 	if (version_compare($wp_version,"2.3",">"))
 	{
 		exit ($exit_msg);
 	}
-	
+
 }
 ?>


### PR DESCRIPTION
Digg Digg stylesheet was being blocked on our website with enforced HTTPS. This fixes that, as well as improves upon how the stylesheet should be loaded based on WordPress best practices (using the wp_enqueue_scripts action hook).

Also removed a few lines of code that checked for a few core constants. Seems extremely paranoid. (Sorry for the whitespace differences. My editor gets rid of all whitespace on blank lines and at the end of lines).
