### PR TITLE
More flexibility over position of floating bar

### DIFF
--- a/digg-digg/digg-digg.php
+++ b/digg-digg/digg-digg.php
@@ -330,8 +330,21 @@ function integrateFloatingButtonsIntoWpContent($dd_floating_button_for_display,$
 			$dd_lazyLoad_scheduler_script = "<script type=\"text/javascript\"> jQuery(document).ready(function($) { " . $dd_lazyLoad_scheduler_script . " }); </script>";
 		}
 
+        // See if the post has custom meta tags to override the position of the top/y coord
+        global $wp_query;
+        $post = $wp_query->post; //get post content
+        $id = $post->ID; //get post id
+
+        $dd_override_start_anchor_id = get_post_meta( $id, 'dd_override_start_anchor_id', true );
+        $dd_override_top_offset = get_post_meta( $id, 'dd_override_top_offset', true );
+
 		// $floatingCSS = '<style type="text/css" media="screen">' . $ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_INITIAL_POSITION] . '</style>';
-		$floatingJSOptions = '<script type="text/javascript">var dd_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT])?($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT]):DD_FLOAT_OPTION_LEFT_VALUE).'; var dd_top_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_TOP])?($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_TOP]):DD_FLOAT_OPTION_TOP_VALUE).';</script>';
+        $floatingJSOptions = '<script type="text/javascript">';
+		$floatingJSOptions .= 'var dd_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT]) ? ($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT]) : DD_FLOAT_OPTION_LEFT_VALUE).';';
+        $floatingJSOptions .= 'var dd_top_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_TOP]) ? ($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_TOP]) : DD_FLOAT_OPTION_TOP_VALUE).';';
+        $floatingJSOptions .= 'var dd_override_start_anchor_id = "'. $dd_override_start_anchor_id . '";';
+        $floatingJSOptions .= 'var dd_override_top_offset = "'. $dd_override_top_offset . '";';
+        $floatingJSOptions .= '</script>';
 		$floatingJS = '<script type="text/javascript" src="' . DD_PLUGIN_URL . '/js/diggdigg-floating-bar.js?ver=' . DD_VERSION . '"></script>';
 
 		$dd_floating_bar = "<div class='dd_outer'><div class='dd_inner'>" . $floatButtonsContainer . "</div></div>" . $floatingJSOptions . $floatingJS . $dd_lazyLoad_scheduler_script . $dd_lazyLoad_jQuery_script;

--- a/digg-digg/js/diggdigg-floating-bar.js
+++ b/digg-digg/js/diggdigg-floating-bar.js
@@ -5,13 +5,21 @@ jQuery(document).ready(function(){
 
 	var $floating_bar = jQuery('#dd_ajax_float');
 	
-	var $dd_start = jQuery('#dd_start');
+    var dd_anchorId = 'dd_start';
+    if ( typeof dd_override_start_anchor_id !== 'undefined' && dd_override_start_anchor_id.length > 0 ) {
+        dd_anchorId = dd_override_start_anchor_id;
+    }
+
+	var $dd_start = jQuery( '#' + dd_anchorId );
 	var $dd_end = jQuery('#dd_end');
 	var $dd_outer = jQuery('.dd_outer');
 	
 	// first, move the floating bar out of the content to avoid position: relative issues
 	$dd_outer.appendTo('body');
 	
+    if ( typeof dd_override_top_offset !== 'undefined' && dd_override_top_offset.length > 0 ) {
+        dd_top_offset_from_content = parseInt( dd_override_top_offset );
+    }
 	dd_top = parseInt($dd_start.offset().top) + dd_top_offset_from_content;
 	
 	if($dd_end.length){


### PR DESCRIPTION
This pull request has small changes that allow a plugin user to better control vertical positioning of the floating bar. The custom positioning can be set per page. This functionality has been requested several times in the plugin's support forum on Wordpress.org.

In the interest of making minimal code changes, it does this by using the existing Custom Fields interface of WordPress:

If the user creates a custom field named "dd_override_start_anchor_id" and gives it a value of a DOM id on the page, the floating bar will align itself vertically to that DOM element instead of the default "dd_start" (which itself is aligned to the top of the post content area). Note that the name of the DOM element should NOT include the '#' prefix.

In addition, the user can create a custom field named "dd_override_top_offset" and give it an integer value in pixels. Positive values move the floating bar downward from the DOM element it is anchored to, negative values move it upward. Note that the value should NOT include a "px" suffix although the code uses parseInt() so it should be resilient to this.

One can choose to use one or both of these custom fields at the same time.
