### PR TITLE
Load floating bar JavaScript in <head> using standard WP script queueing

### DIFF
--- a/digg-digg/digg-digg.php
+++ b/digg-digg/digg-digg.php
@@ -26,7 +26,7 @@ require_once 'include/dd-upgrade.php';
 //function to be run when the plugin is activated
 register_activation_hook( __FILE__, 'dd_run_when_plugin_activated' );
 
-add_action('init', 'dd_enable_required_js_in_wordpress' );
+add_action( 'wp_enqueue_scripts', 'dd_enable_required_js_in_wordpress' );
 add_action( 'wp_enqueue_scripts', 'dd_wp_enqueue_styles' );
 add_action( 'wp_head', 'dd_get_thumbnails_for_fb' );
 add_filter( 'the_excerpt', 'dd_hook_wp_content' );
@@ -344,16 +344,14 @@ function integrateFloatingButtonsIntoWpContent($dd_floating_button_for_display,$
 	        $dd_override_top_offset = 0;
         }
 
-		// $floatingCSS = '<style type="text/css" media="screen">' . $ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_INITIAL_POSITION] . '</style>';
         $floatingJSOptions = '<script type="text/javascript">';
 		$floatingJSOptions .= 'var dd_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT]) ? ($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT]) : DD_FLOAT_OPTION_LEFT_VALUE).';';
         $floatingJSOptions .= 'var dd_top_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_TOP]) ? ($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_TOP]) : DD_FLOAT_OPTION_TOP_VALUE).';';
         $floatingJSOptions .= 'var dd_override_start_anchor_id = "'. $dd_override_start_anchor_id . '";';
         $floatingJSOptions .= 'var dd_override_top_offset = "'. $dd_override_top_offset . '";';
         $floatingJSOptions .= '</script>';
-		$floatingJS = '<script type="text/javascript" src="' . DD_PLUGIN_URL . '/js/diggdigg-floating-bar.js?ver=' . DD_VERSION . '"></script>';
 
-		$dd_floating_bar = "<div class='dd_outer'><div class='dd_inner'>" . $floatButtonsContainer . "</div></div>" . $floatingJSOptions . $floatingJS . $dd_lazyLoad_scheduler_script . $dd_lazyLoad_jQuery_script;
+		$dd_floating_bar = "<div class='dd_outer'><div class='dd_inner'>" . $floatButtonsContainer . "</div></div>" . $floatingJSOptions . $dd_lazyLoad_scheduler_script . $dd_lazyLoad_jQuery_script;
 		$dd_start_anchor = '<a id="dd_start"></a>';
 
 		if(!$ddFloatDisplay[DD_COMMENT_ANCHOR_OPTION][DD_COMMENT_ANCHOR_OPTION_STATUS]){
@@ -407,11 +405,9 @@ function integrateFloatingButtonsIntoWpContent_footerload($dd_floating_button_fo
 			$dd_lazyLoad_scheduler_script = "<script type=\"text/javascript\">function dd_float_scheduler(){ jQuery(document).ready(function($) { " . $dd_lazyLoad_scheduler_script . " }); }</script>";
 		}
 
-		// $floatingCSS = '<style type="text/css" media="screen">' . $ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_INITIAL_POSITION] . '</style>';
 		$floatingJSOptions = '<script type="text/javascript">var dd_offset_from_content = '.(!empty($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT])?($ddFloatDisplay[DD_FLOAT_OPTION][DD_FLOAT_OPTION_LEFT]):DD_FLOAT_OPTION_LEFT_VALUE).';</script>';
-		$floatingJS = '<script type="text/javascript" src="' . DD_PLUGIN_URL . '/js/diggdigg-floating-bar.js?ver=' . DD_VERSION . '"></script>';
 
-		$dd_floating_bar = "<div class='dd_outer'><div class='dd_inner'>" . $floatButtonsContainer . "</div></div>" . $floatingCSS . $floatingJSOptions . $floatingJS . $dd_lazyLoad_scheduler_script . $dd_lazyLoad_jQuery_script;
+		$dd_floating_bar = "<div class='dd_outer'><div class='dd_inner'>" . $floatButtonsContainer . "</div></div>" . $floatingJSOptions . $dd_lazyLoad_scheduler_script . $dd_lazyLoad_jQuery_script;
 
 		$dd_start_anchor = '<a id="dd_start"></a>';
 

--- a/digg-digg/include/dd-helper.php
+++ b/digg-digg/include/dd-helper.php
@@ -144,6 +144,8 @@ function dd_enable_required_js_in_wordpress() {
 		//jQuery need to put on head
 		wp_enqueue_script('jquery');
 	}
+
+    wp_enqueue_script( 'diggdigg', DD_PLUGIN_URL . 'js/diggdigg-floating-bar.js', array(), DD_VERSION );
 }
 
 //filter for ajax floating javascript

--- a/digg-digg/js/diggdigg-floating-bar.js
+++ b/digg-digg/js/diggdigg-floating-bar.js
@@ -11,6 +11,10 @@ jQuery(document).ready(function(){
     }
 
 	var $dd_start = jQuery( '#' + dd_anchorId );
+    // if anchor element is not found then the rest is moot. Bail out to avoid errors.
+    if ( $dd_start.length === 0 ) {
+        return;
+    }
 	var $dd_end = jQuery('#dd_end');
 	var $dd_outer = jQuery('.dd_outer');
 	


### PR DESCRIPTION
This proposed change loads the floating bar JavaScript using wp_enqueue_scripts(). This has two benefits:
1) It keeps the JavaScript from embedding in the HTML body (messy)
2) It improves compatibility with WordPress minifiers (such as BWP_Minify) that use the list of scripts passed to that function.

With this change, my digg-digg JavaScript can now be automatically minified and concatenated with the rest of my JS to help speed up my site load times.
