### PR TITLE
Fixes FB Like button share box getting cropped.

### DIFF
--- a/digg-digg/css/diggdigg-style.css
+++ b/digg-digg/css/diggdigg-style.css
@@ -177,6 +177,10 @@
 	padding:4px
 }
 
+.dd_button .fb_iframe_widget iframe {
+	max-width: inherit;
+}
+
 .dd_fblike_xfbml_ajax_left_float {
 	padding-left:3px
 }


### PR DESCRIPTION
CSS fix for a problem with the FB Like button. When a user clicks on the button the FB box with the article summary and picture is cropped, perhaps only for horizontal buttons? A few people are having the same problem: http://wordpress.org/support/topic/xfbmliframe-hides-beneath-the-theme?replies=5 - applied a fix using max-width suggested in this StackOverflow article http://stackoverflow.com/questions/6444265/facebook-like-comment-box-getting-cut-off-vertically-and-horizontally
