### PR TITLE
split() is depreciated, replaced it with explode()

### DIFF
--- a/digg-digg/include/dd-manual.php
+++ b/digg-digg/include/dd-manual.php
@@ -382,7 +382,7 @@ function dd_getPostData() {
     $id = $post->ID; //get post id
     $postlink = get_permalink($id); //get post link
     $title = trim($post->post_title); // get post title
-    $link = split(DD_DASH,$postlink); //split the link with '#', for comment
+    $link = explode(DD_DASH,$postlink); //split the link with '#', for comment
     
     return array( 'id' => $id, 'link' => $link[0], 'title' => $title );
 }


### PR DESCRIPTION
Just getting rid of an error when wp-config.php has WP_DEBUG set to true